### PR TITLE
不让master的commit重写docker的latest标签

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -34,22 +34,29 @@ jobs:
         id: prepare
         run: |
           if [[ $GITHUB_REF == refs/tags/* ]]; then
-            echo ::set-output name=version::${GITHUB_REF#refs/tags/}
             echo ::set-output name=ref::${GITHUB_REF#refs/tags/}
           else
-            echo ::set-output name=version::snapshot
             echo ::set-output name=ref::${{ github.sha }}
           fi
           echo ::set-output name=docker_platforms::linux/amd64,linux/arm64,linux/ppc64le,linux/s390x,linux/386
           echo ::set-output name=docker_image::${{ secrets.DOCKERUSERNAME }}/trojan-go-fork
       - name: Build and push docker image
         run: |
-          docker buildx build --platform ${{ steps.prepare.outputs.docker_platforms }} \
-          --output "type=image,push=true" \
-          --tag "${{ steps.prepare.outputs.docker_image }}:${{ steps.prepare.outputs.version }}" \
-          --tag "${{ steps.prepare.outputs.docker_image }}:latest" \
-          --build-arg REF=${{ steps.prepare.outputs.ref }} \
-          --file Dockerfile .
+          if [[ $GITHUB_REF == refs/tags/* ]]; then
+            docker buildx build --platform ${{ steps.prepare.outputs.docker_platforms }} \
+            --output "type=image,push=true" \
+            --tag "${{ steps.prepare.outputs.docker_image }}:${GITHUB_REF#refs/tags/}" \
+            --tag "${{ steps.prepare.outputs.docker_image }}:latest" \
+            --build-arg REF=${{ steps.prepare.outputs.ref }} \
+            --file Dockerfile .
+          else
+            docker buildx build --platform ${{ steps.prepare.outputs.docker_platforms }} \
+            --output "type=image,push=true" \
+            --tag "${{ steps.prepare.outputs.docker_image }}:snapshot" \
+            --build-arg REF=${{ steps.prepare.outputs.ref }} \
+            --file Dockerfile .
+          fi
+
   test:
     needs: build
     runs-on: ubuntu-latest


### PR DESCRIPTION
上次解决玩docker image的问题后我一直对CI有一处感觉有问题, 但因为原版trojan-go的CI也是这么写的我也就没多研究, 没想到这次看到你往master里push了一下, 还真出这个问题了

问题主要是一旦master被push了, 制作`snapshot`标签的docker image的CI会一同把`latest`也指向`snapshot`. 但按理来说, `latest`应该永远指向最新的release, `snapshot`指向最新的master才对. 
![image](https://user-images.githubusercontent.com/17377423/193104126-86160d3e-39a6-4ac6-8211-b4c2a5e2a958.png)

问题的修复也很简单, 给build image那一步加一个和Prepare那一步一模一样的if else来区分release和snapshot, 然后两边分别用不同的`--tag`

我没有测试过, 可能还得麻烦你帮忙看看